### PR TITLE
Reduce .travis.yml package hacks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ notifications:
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia -e 'Pkg.add("Images"); Pkg.checkout("Images")'
-  - julia -e 'Pkg.clone(pwd()); Pkg.build("QuartzImageIO.jl");'
-  - julia -e 'Pkg.test("QuartzImageIO.jl"; coverage=true)'
+  - julia -e 'Pkg.clone(pwd()); Pkg.build("QuartzImageIO");'
+  - julia -e 'Pkg.test("QuartzImageIO"; coverage=true)'
 after_success:
-  - julia -e 'cd(Pkg.dir("QuartzImageIO.jl")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder()); Codecov.submit(process_folder())'
+  - julia -e 'cd(Pkg.dir("QuartzImageIO")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder()); Codecov.submit(process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ notifications:
 # uncomment the following lines to override the default test script
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'Pkg.clone("Images"); Pkg.clone("FileIO")'
+  - julia -e 'Pkg.clone("Images"); Pkg.checkout("FileIO")'
   - julia -e 'Pkg.clone(pwd()); Pkg.build("QuartzImageIO");'
   - julia -e 'Pkg.test("QuartzImageIO"; coverage=true)'
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ notifications:
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia -e 'Pkg.add("Images"); Pkg.checkout("Images")'
-  - julia -e 'Pkg.clone(pwd()); Pkg.build("QuartzNativeIO");'
-  - julia -e 'Pkg.test("QuartzNativeIO"; coverage=true)'
+  - julia -e 'Pkg.clone(pwd()); Pkg.build("QuartzImageIO.jl");'
+  - julia -e 'Pkg.test("QuartzImageIO.jl"; coverage=true)'
 after_success:
-  - julia -e 'cd(Pkg.dir("QuartzNativeIO")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder()); Codecov.submit(process_folder())'
+  - julia -e 'cd(Pkg.dir("QuartzImageIO.jl")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder()); Codecov.submit(process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ notifications:
 # uncomment the following lines to override the default test script
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'Pkg.add("Images"); Pkg.checkout("Images")'
+  - julia -e 'Pkg.clone("Images"); Pkg.clone("FileIO")'
   - julia -e 'Pkg.clone(pwd()); Pkg.build("QuartzImageIO");'
   - julia -e 'Pkg.test("QuartzImageIO"; coverage=true)'
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ notifications:
 # uncomment the following lines to override the default test script
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'Pkg.clone("https://github.com/JuliaIO/FileIO.jl.git")'
-  - julia -e 'Pkg.clone(pwd()); Pkg.checkout("Images", "sd/fileio"); Pkg.build("QuartzNativeIO");'
+  - julia -e 'Pkg.add("Images"); Pkg.checkout("Images")'
+  - julia -e 'Pkg.clone(pwd()); Pkg.build("QuartzNativeIO");'
   - julia -e 'Pkg.test("QuartzNativeIO"; coverage=true)'
 after_success:
   - julia -e 'cd(Pkg.dir("QuartzNativeIO")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder()); Codecov.submit(process_folder())'


### PR DESCRIPTION
I'm quite puzzled by [this error](https://travis-ci.org/JuliaIO/QuartzImageIO.jl/jobs/82709157), since the `runtests.jl` file is clearly there. Any ideas?