### PR TITLE
Adding typealias and automatically releasing objects

### DIFF
--- a/src/QuartzImageIO.jl
+++ b/src/QuartzImageIO.jl
@@ -232,12 +232,13 @@ end
 
 function save_and_release(cg_img::Ptr{Void}, # CGImageRef
                           fname, image_type::AbstractString)
-    out_url = CFURLCreateWithFileSystemPath(fname);
-    out_dest = CGImageDestinationCreateWithURL(out_url, image_type, 1);
-    CGImageDestinationAddImage(out_dest, cg_img);
-    CGImageDestinationFinalize(out_dest);
+    out_url = CFURLCreateWithFileSystemPath(fname)
+    out_dest = CGImageDestinationCreateWithURL(out_url, image_type, 1)
+    CGImageDestinationAddImage(out_dest, cg_img)
+    CGImageDestinationFinalize(out_dest)
     CFRelease(out_dest)
     CFRelease(out_url)
+    CGImageRelease(cg_img)
     nothing
 end
 


### PR DESCRIPTION
I'd like to add GIF support this week, and I wanted to clean up the code a bit beforehand. I'm not sure I like the typealias changes. It looks noisier, but it's probably for the best?

Also, `save_and_release` never actually released the image, so there was a memory leak, now fixed.