### PR TITLE
Support arrays with non-1 indexing

### DIFF
--- a/src/QuartzImageIO.jl
+++ b/src/QuartzImageIO.jl
@@ -367,8 +367,7 @@ mapCG(x::Normed) = x
 
 # Make the data contiguous in memory, because writers don't handle stride.
 to_contiguous(A::Array) = A
-to_contiguous(A::AbstractArray) = convert(Array, A)
-to_contiguous(A::SubArray) = copy(A)
+to_contiguous(A::AbstractArray) = collect(A)
 to_contiguous(A::BitArray) = convert(Array{N0f8}, A)
 to_contiguous(A::ColorView) = to_contiguous(channelview(A))
 

--- a/src/QuartzImageIO.jl
+++ b/src/QuartzImageIO.jl
@@ -232,7 +232,8 @@ function save_{R <: DataFormat}(f::File{R}, img::AbstractArray;
     end
     permute_horizontal && (imgm = permutedims_horizontal(imgm))
     ndims(imgm) > 3 && error("QuartzImageIO: At most 3 dimensions are supported for saving.")
-    buf = to_explicit(to_contiguous(imgm))
+    contig = to_contiguous(imgm)
+    buf = to_explicit(contig)
     # Color type and order
     T = eltype(img)
     bitmap_info = zero(UInt32)
@@ -280,8 +281,8 @@ function save_{R <: DataFormat}(f::File{R}, img::AbstractArray;
         bitmap_info |= kCGBitmapByteOrder32Little
     end
     # Image size
-    width, height, = size(imgm)
-    nframes = size(imgm, 3)
+    width, height = size(contig)
+    nframes = size(contig, 3)
     bytes_per_row = width*components*bits_per_component ÷ 8
     # Output type
     apple_format_names = Dict(format"BMP" => "com.microsoft.bmp",

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,3 @@
 TestImages 0.1.3
 ImageAxes 0.2
+OffsetArrays

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Base.Test, FileIO, QuartzImageIO, ColorTypes
 using FixedPointNumbers, TestImages, ImageAxes
 using Images  # For ImageMeta
+using OffsetArrays
 
 # Saving notes:
 # autumn_leaves and toucan fail as of November 2015. The "edges" of the
@@ -258,4 +259,14 @@ end
     end
 end
 
+@testset "OffsetArrays" begin
+    img = OffsetArray(Gray{N0f8}[1 0; 0 1], 0:1, 3:4)
+    fn = joinpath(mydir, "indices.png")
+    save(fn, img)
+    imgr = load(fn)
+    @test imgr == parent(img)
+end
+
 rm(mydir, recursive=true)
+
+@test !isdefined(:ImageMagick)


### PR DESCRIPTION
I've also pushed a branch, julia-0.5, supporting the same change on 0.5. Ideally that could be tagged in the 0.2 series.
