### PR TITLE
use specific minimum julia version in REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-dev.2782
 FileIO 0.0.4
 Images 0.6
 ColorTypes 0.3


### PR DESCRIPTION
`const Color1{T}` syntax would not work on earlier 0.6.0-dev,
so better to stick to julia-0.5-compatible versions of the package there