### PR TITLE
fix save-load test for larger Lab gamut introduced by ColorTypes v0.6.1

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -271,12 +271,19 @@ end
     @testset "Lab" begin
         srand(42)
         img = rand(Lab{Float32}, 8, 10)
+
+        # round-trip the image through RGB to ensure we have Lab values
+        # which can actually be represented in RGB space
+        img .= Lab.(RGB.(img))
+
         out_name = joinpath(mydir, "Lab.png")
         save(out_name, img)
-        oimg = load(out_name)
-        @test Lab.(oimg)[1].l ≈ img[1].l atol=0.9
-        @test Lab.(oimg)[1].a ≈ img[1].a atol=0.4
-        @test Lab.(oimg)[1].b ≈ img[1].b atol=0.6
+        oimg = Lab.(load(out_name))
+        for I in eachindex(img)
+            @test oimg[I].l ≈ img[I].l atol=0.9
+            @test oimg[I].a ≈ img[I].a atol=0.4
+            @test oimg[I].b ≈ img[I].b atol=0.6
+        end
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -271,18 +271,17 @@ end
     @testset "Lab" begin
         srand(42)
         img = rand(Lab{Float32}, 8, 10)
-
-        # round-trip the image through RGB to ensure we have Lab values
-        # which can actually be represented in RGB space
-        img .= Lab.(RGB.(img))
-
         out_name = joinpath(mydir, "Lab.png")
         save(out_name, img)
         oimg = Lab.(load(out_name))
         for I in eachindex(img)
-            @test oimg[I].l ≈ img[I].l atol=0.9
-            @test oimg[I].a ≈ img[I].a atol=0.4
-            @test oimg[I].b ≈ img[I].b atol=0.6
+            # Comparing oimg[I] against img[I] may fail because
+            # information was lost when saving the Lab values as 
+            # RGB. Instead, we just verify that oimg[I] = Lab(RGB(img[I]))
+            expected = Lab(RGB(img[I]))
+            @test oimg[I].l ≈ expected.l atol=0.9
+            @test oimg[I].a ≈ expected.a atol=0.4
+            @test oimg[I].b ≈ expected.b atol=0.6
         end
     end
 end


### PR DESCRIPTION
Fixes #43 by accounting for the fact that saving some Lab colors as RGB discards information. 