### PR TITLE
don't directly depend on ColorTypes and FixedPointNumbers

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,16 @@
+name: CompatHelper
+
+on:
+  schedule:
+    - cron: '00 00 * * *'
+
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+/Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuartzImageIO"
 uuid = "dca85d43-d64c-5e67-8c65-017450d5d020"
-version = "0.7.1"
+version = "0.7.2"
 
 [deps]
 ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"

--- a/Project.toml
+++ b/Project.toml
@@ -3,20 +3,16 @@ uuid = "dca85d43-d64c-5e67-8c65-017450d5d020"
 version = "0.7.1"
 
 [deps]
-ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [compat]
-ColorTypes = "0.9, 0.10"
 ColorVectorSpace = "0.8"
 FileIO = "1"
-FixedPointNumbers = "0.6.1, 0.7"
 ImageAxes = "0.6"
-ImageCore = "0.7, 0.8"
+ImageCore = "0.8.1"
 ImageMetadata = "0.5, 0.6, 0.7, 0.8"
 TestImages = "0.4, 0.5, 0.6, 1"
 julia = "1"

--- a/src/QuartzImageIO.jl
+++ b/src/QuartzImageIO.jl
@@ -1,6 +1,7 @@
 module QuartzImageIO
 
-using ImageCore, ColorTypes, ColorVectorSpace, FixedPointNumbers, Libdl
+# ColorTypes and FixedPointNumbers are reexported by ImageCore v0.8.1
+using ImageCore, ColorVectorSpace, Libdl
 import FileIO: DataFormat, @format_str, File, Stream, filename, stream
 
 const CFURLRef = Ptr{Cvoid}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
-using Test, Random, FileIO, QuartzImageIO, ColorTypes
-using FixedPointNumbers, TestImages, ImageAxes
+using Test, Random, FileIO, QuartzImageIO
+using ImageCore
+using TestImages, ImageAxes
 using ImageMetadata
 using OffsetArrays
 


### PR DESCRIPTION
I just hit this in #65 

Given that this package already depends on ImageCore, it doesn't need to directly maintain `ColorTypes` and `FixedPointNumber` versions.

I also added a CompatHelper for this.

closes #61 
closes #64