### PR TITLE
Check whether ColorView is defined

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuartzImageIO"
 uuid = "dca85d43-d64c-5e67-8c65-017450d5d020"
-version = "0.7.2"
+version = "0.7.3"
 
 [deps]
 ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"

--- a/src/QuartzImageIO.jl
+++ b/src/QuartzImageIO.jl
@@ -366,8 +366,9 @@ mapCG(x::Normed) = x
 to_contiguous(A::Array) = A
 to_contiguous(A::AbstractArray) = collect(A)
 to_contiguous(A::BitArray) = convert(Array{N0f8}, A)
-to_contiguous(A::ColorView) = to_contiguous(channelview(A))
-
+if isdefined(ImageCore, :ColorView)
+    to_contiguous(A::ColorView) = to_contiguous(channelview(A))
+end
 to_explicit(A::Array{C}) where C <: Colorant = to_explicit(channelview(A))
 to_explicit(A::Base.ReinterpretArray{T}) where T = to_explicit(copyto!(Array{T}(undef, size(A)), A))
 to_explicit(A::Array{T}) where T <: Normed = rawview(A)


### PR DESCRIPTION
ColorView has been deprecated since Nov 2017, but only as a constructor. Hence direct uses of the type did not get noticed. I may "resurrect" `ColorView` in new form, and if so the existing definition here ~~should still work~~might work in limited cases, but in case we go through a period where there is no `ColorView` we should check for its existence.

xref https://github.com/JuliaIO/ImageMagick.jl/pull/185. Would be good to get a new release out pronto since I expect ColorView will either disappear or change implementation within the next couple of months, and best to get this disseminated first.